### PR TITLE
Fix undefined currentOnline variable

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 // Rota principal
 app.get('/', (req, res) => {
-  res.render('index');
+  res.render('index', { onlineCount });
 });
 
 // --- SIMPLE MATCHMAKING AND ONLINE COUNTER ---

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -174,8 +174,18 @@
     </style>
 </head>
 <body>
+    <script src="/socket.io/socket.io.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.min.js"></script>
     <script>
+        let currentOnline = <%= typeof onlineCount !== 'undefined' ? onlineCount : 0 %>;
+        const socket = io();
+        socket.on('onlineCount', count => {
+            currentOnline = count;
+            if (typeof window.updateOnlineCount === 'function') {
+                window.updateOnlineCount(count);
+            }
+        });
+
         // --- API CONFIGURATION ---
         const BASE_API_URL = 'https://howdyhey.squareweb.app';
         const API_ENDPOINTS = {


### PR DESCRIPTION
## Summary
- pass onlineCount from Express to EJS
- initialize socket.io client to keep track of online players
- update menu to show initial online count

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68548a37afb08329930c3d2e383f19f7