### PR TITLE
Fix PointerLockControls and switch to modules

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -1,3 +1,6 @@
+import * as THREE from 'https://unpkg.com/three@0.156.1/build/three.module.js';
+import { PointerLockControls } from 'https://unpkg.com/three@0.156.1/examples/jsm/controls/PointerLockControls.js';
+
 let scene, camera, renderer, controls, cube, clock;
 
 function init() {
@@ -19,7 +22,7 @@ function init() {
 
   camera.position.z = 5;
 
-  controls = new THREE.PointerLockControls(camera, document.body);
+  controls = new PointerLockControls(camera, document.body);
   document.body.addEventListener('click', () => controls.lock());
 
   clock = new THREE.Clock();

--- a/public/index.html
+++ b/public/index.html
@@ -11,8 +11,6 @@
 </head>
 <body>
 <div id="hud">Time: <span id="time">0</span></div>
-<script src="https://unpkg.com/three@0.156.1/build/three.min.js"></script>
-<script src="https://unpkg.com/three@0.156.1/examples/js/controls/PointerLockControls.js"></script>
-<script src="game.js"></script>
+<script type="module" src="game.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- switch game script loading to a module
- import `three` and `PointerLockControls` via ES modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68549200a6e88329adfccacd872edd03