### PR TITLE
Improve HUD layout and add pixel art ground

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 <style>
   body { margin:0; overflow:hidden; background:#111; color:#fff; font-family:Arial, sans-serif; }
   canvas { background:linear-gradient(#222,#444); display:block; margin:0 auto; border:2px solid #555; }
+  #viewport { position:relative; width:800px; margin:0 auto; }
   #ui {
     position:absolute;
     bottom:10px; left:10px;
@@ -28,6 +29,7 @@
 </style>
 </head>
 <body>
+<div id="viewport">
 <canvas id="game"></canvas>
 <div id="ui">
   <div>HP:<span id="hp"></span></div>
@@ -43,6 +45,7 @@
 </div>
 <div id="upgradeContainer"></div>
 <div id="menu"><h1>Sidescroller</h1><button id="startBtn">Start Game</button></div>
+</div>
 <script>
 const canvas=document.getElementById('game');
 const ctx=canvas.getContext('2d');
@@ -89,6 +92,10 @@ const upgrades=[
 const player=new Player();
 const bullets=[];const enemies=[];const enemyBullets=[];let spawnTimer=0;let score=0;
 const ground=[{x:0,y:560,w:200,h:40},{x:200,y:520,w:200,h:80},{x:400,y:480,w:200,h:120},{x:600,y:440,w:200,h:160}];
+const groundTile=new Image();
+groundTile.src='data:image/svg+xml,'+encodeURIComponent(`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="16" height="16" fill="#764d1a"/><rect width="16" height="3" fill="#2f9e44"/><rect y="1" width="16" height="1" fill="#3fb954"/><rect x="2" y="5" width="2" height="2" fill="#5a3913"/><rect x="8" y="8" width="2" height="2" fill="#5a3913"/><rect x="4" y="12" width="2" height="2" fill="#5a3913"/><rect x="12" y="10" width="2" height="2" fill="#5a3913"/></svg>`);
+let groundPattern;
+groundTile.onload=()=>{groundPattern=ctx.createPattern(groundTile,'repeat');};
 
 function spawnParticles(x,y,color,count=8){
   for(let i=0;i<count;i++){
@@ -153,7 +160,7 @@ function shootBullet(){const dx=mouse.x-(player.x+player.w/2);const dy=mouse.y-(
 function shootEnemy(e){const dx=player.x-e.x;const dy=player.y-e.y;const len=Math.hypot(dx,dy);const vx=dx/len*4;const vy=dy/len*4;enemyBullets.push(new Bullet(e.x,e.y,vx,vy,5,10,'enemy'));}
 function draw(){
   ctx.clearRect(0,0,canvas.width,canvas.height);
-  ctx.fillStyle='#080';
+  ctx.fillStyle=groundPattern||'#080';
   ground.forEach(g=>ctx.fillRect(g.x,g.y,g.w,g.h));
   particles.forEach(p=>{
     ctx.globalAlpha=p.life/p.maxLife;


### PR DESCRIPTION
## Summary
- move HUD elements inside a viewport container so they overlay the canvas
- add repeating pixel-art ground texture using SVG

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685499b735d48329a9d841b8cafe9ecc