### PR TITLE
Add Game Over overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,19 @@
     font-size:14px;
     color:#ccc;
   }
+  #gameOver {
+    display:none;
+    position:absolute;
+    top:50%;
+    left:50%;
+    transform:translate(-50%,-50%);
+    background:rgba(0,0,0,0.8);
+    color:#fff;
+    padding:20px 40px;
+    border-radius:12px;
+    font-size:32px;
+    text-align:center;
+  }
 </style>
 </head>
 <body>
@@ -141,6 +154,10 @@
   <p id="credits">Credits: JAIR EDINGER</p>
 </div>
 <div id="pauseOverlay">PAUSED</div>
+<div id="gameOver">
+  Game Over<br>
+  <button id="restartBtn">Reiniciar</button>
+</div>
 </div>
 <script>
 const canvas=document.getElementById('game');
@@ -161,6 +178,12 @@ canvas.addEventListener('mousedown',()=>mouse.down=true);
 canvas.addEventListener('mouseup',()=>mouse.down=false);
 document.getElementById('pauseBtn').onclick=togglePause;
 document.addEventListener('keydown',e=>{if(e.key.toLowerCase()==='p')togglePause();});
+document.getElementById('restartBtn').onclick=()=>{
+  initGame();
+  document.getElementById('gameOver').style.display='none';
+  gamePaused=false;
+  last=performance.now();
+};
 class Entity{constructor(x,y,w,h){this.x=x;this.y=y;this.vx=0;this.vy=0;this.w=w;this.h=h;}}
 class Player extends Entity{constructor(){super(100,500,30,40);this.speed=3;this.jump=12;this.maxHp=100;this.hp=100;this.exp=0;this.level=1;this.expToLevel=100;this.inv=0;this.shootCd=0;this.shootDelay=400;this.projDmg=10;this.projSize=5;this.attackChoices=3;}}
 class Enemy extends Entity{constructor(str){const x=Math.random()*canvas.width;super(x,-20,30,30);this.follow=false;this.hp=20+str*5;this.shootDelay=1000;this.shootCd=this.shootDelay;}}
@@ -256,12 +279,12 @@ function handleCollisions(){
      }
    });
  });
- enemyBullets.forEach((b,i)=>{
+enemyBullets.forEach((b,i)=>{
    if(rectIntersect(b,player)&&player.inv<=0){
      spawnParticles(b.x,b.y,'red');
      player.hp-=10;player.inv=500;
      enemyBullets.splice(i,1);
-     if(player.hp<=0){alert('Game Over');location.reload();}
+     if(player.hp<=0){showGameOver();}
    }
  });
  enemies.forEach((e,j)=>{
@@ -327,6 +350,11 @@ function toggleFullScreen(){
 function togglePause(){
   gamePaused=!gamePaused;
   document.getElementById('pauseOverlay').style.display=gamePaused?'block':'none';
+}
+
+function showGameOver(){
+  gamePaused=true;
+  document.getElementById('gameOver').style.display='block';
 }
 function showUpgrades(){
   gamePaused=true;mouse.down=false;


### PR DESCRIPTION
## Summary
- display a `Game Over` overlay with a restart button when the player dies
- restart the game through `initGame()` instead of reloading the page

## Testing
- `tidy -errors -q index.html`

------
https://chatgpt.com/codex/tasks/task_e_6854a6c527f88329a065162d9d0be2bd